### PR TITLE
feat: rustdoc_include for .kt and .java files

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "The Cookbook"
+
+[output.html.code.hidelines]
+java = "# "
+kt = "# "


### PR DESCRIPTION
refers to:
[including a file but initially hiding all except specified lines](https://rust-lang.github.io/mdBook/format/mdbook.html#including-a-file-but-initially-hiding-all-except-specified-lines)

added keys to book.toml to enable usage of the {{#rustdoc_include path/to/file:start:end}} system to handily include the contents of another file, with outside lines excluded for .java and .kt files

for example, including a .kt file:
\`\`\`kotlin
{{#rustdoc_include path/to/file/kotlin.kt:5:10}}
\`\`\`

will include the lines 5-10 of the file, and hide the others, allowing a handy button to reveal them, this is a feature that could be used to rework some of the pre-exisitng articles, in order to provide both short and readable examples at the same time as full featured valid code