### PR TITLE
Rewrite and fix typos on various pages

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -25,8 +25,8 @@
 - [Syncing two linear slide motors using a PID(F) Controller](./pidf_controllers/syncing_two_linear_slide_motors_using_a_pidf_controller/syncing_two_linear_slide_motors_using_a_pidf_controller.md)
 
 # Electrical
-- [Why we should only use USB 3.0?](./electrical/why_we_should_only_use_usb_30.md)
-- [Where should I put my odometry pods?](./electrical/how_to_wire_odometry_pods.md)
+- [Why to only use USB 3.0](./electrical/why_we_should_only_use_usb_30.md)
+- [How to wire odometry pods](./electrical/how_to_wire_odometry_pods.md)
 
 # Miscellaneous
 - [Why Kotlin?](./misc/why_kotlin/why_kotlin.md)

--- a/src/contributors.md
+++ b/src/contributors.md
@@ -6,3 +6,4 @@
 - rjan939 [(github)](https://github.com/rjan939) [(discord)](https://discordapp.com/users/292725814556884995)
 - Froze 'n' Milk [(github)](https://github.com/Froze-N-Milk)
 - Iris [(github)](https://github.com/Iris-TheRainbow) [(discord)](https://discord.com/users/705965203807928381)
+- j5155 [(github)](https://github.com/j5155) [(discord)](https://discord.com/users/496774369054425109)

--- a/src/electrical/how_to_wire_odometry_pods.md
+++ b/src/electrical/how_to_wire_odometry_pods.md
@@ -1,4 +1,4 @@
-# Where should I put my odometry pods?
+# Where to put your odometry pods
 
 ### Ingredients
 
@@ -9,17 +9,28 @@
 ## The Recipe
 
 ### The problem
-The Rev Control Hub and Expansion hub, as found [here](https://blog.eeshwark.com/robotblog/rev-hub-quadrature) by 7244 alum Eeshwar, only has 2 reliable quadrature encoder ports, meaning for teams that use high CPR/PPR encoders, such as the Rev Through Bore encoder, will miss counts on ports 1 and 2.
+The Rev Control Hub and Expansion Hub, as found [here](https://blog.eeshwark.com/robotblog/rev-hub-quadrature) by 7244 alum Eeshwar, only have 2 reliable quadrature encoder ports. 
+This means high CPR/PPR encoders such as the Rev Through Bore encoder will miss counts on ports 1 and 2 which will lead to drift.
 
 
 ### Solutions
 ### 2 Wheel Odometry
-For teams that use a 2 wheel + IMU setup, the solution is simple! AS you don't need drive encoders, put all motors on the main hub and put the odometry encoders on encoder ports 0 and 3 main hub, where you would usually put the motor encoders.
+For teams that use a 2 wheel + IMU setup, the solution is simple! 
+Put the drive motors on the Control Hub. 
+Then, as you don't need drive encoders, you can simply put the odometry on Control Hub encoder ports 0 and 3 where you would usually put the motor encoders.
 
 ### 3 Wheel Odometry
-For teams with 3 wheel odometry, it gets much more complex. Since the most important encoders are the parallel pods, since encoder drift with them will cause heading drift, causing significant localization error across a 30 second autonomous. Since they're the most important, the parallel pods should go in ports 0 and 3 on your main hub. The perpendicular, or strafe pod, is less important to localization, and since mecanum strafe speed is lower, so it is fine to put it in port 1 or 2, as the accuracy loss of using the secondary hub, due to requiring another bulk read, is not worth the increase of a more accurate port.
+For teams with 3 wheel odometry, it is a bit more complex. 
+The most important odometry pods are the parallel ones since encoder drift with them will cause heading drift.
+This can rapidly ruin your localization as heading is used as a basis for all other measurements. 
+Since they're the most important, the parallel pods should go in ports 0 and 3 on the Control Hub. 
+The perpendicular (strafe) pod is less important to localization, so it is fine to put it in port 1 or 2 on the Control Hub.
+
+Note that you should always put odometry on the Control Hub (or at least  all on the same hub) even if you must place it in ports 1 or 2.
+This is because reading from the Expansion Hub requires an additional bulk read.
+This can greatly worsen loop times and is not worth the benefits of using the 0 and 3 ports.
 
 
 
 
-*Last Updated: 2024-02-08*
+*Last Updated: 2024-05-29*

--- a/src/electrical/how_to_wire_odometry_pods.md
+++ b/src/electrical/how_to_wire_odometry_pods.md
@@ -1,4 +1,4 @@
-# Where to put your odometry pods
+# How to wire odometry pods
 
 ### Ingredients
 

--- a/src/electrical/how_to_wire_odometry_pods.md
+++ b/src/electrical/how_to_wire_odometry_pods.md
@@ -26,7 +26,7 @@ This can rapidly ruin your localization as heading is used as a basis for all ot
 Since they're the most important, the parallel pods should go in ports 0 and 3 on the Control Hub. 
 The perpendicular (strafe) pod is less important to localization, so it is fine to put it in port 1 or 2 on the Control Hub.
 
-Note that you should always put odometry on the Control Hub (or at least  all on the same hub) even if you must place it in ports 1 or 2.
+Note that you should always put odometry on the Control Hub (or at least all on the same hub) even if you must place it in ports 1 or 2.
 This is because reading from the Expansion Hub requires an additional bulk read.
 This can greatly worsen loop times and is not worth the benefits of using the 0 and 3 ports.
 

--- a/src/electrical/why_we_should_only_use_usb_30.md
+++ b/src/electrical/why_we_should_only_use_usb_30.md
@@ -1,4 +1,4 @@
-# Why we should only use USB 3.0
+# Why to only use USB 3.0
 
 
 ### Ingredients
@@ -16,13 +16,17 @@
 The Control Hub has a lot of nuances that many people do not know of, including the dangers of the onboard USB 2.0 port.
 
 ### The Problem
-The Control Hub's USB 2.0 port shares a ground with the wifi chipset on the Control Hub, providing a path for a static shock to cause a disconnect mid match, given a static shock to the USB device.
+The Control Hub's USB 2.0 port shares a ground with the Wi-Fi chipset on the Control Hub.
+This provides a path for a static shock to the USB device to cause a Wi-Fi disconnect mid-match.
 
 
 ### How to Mitigate the Problem
-The best way to mitigate the problem is to not use the USB 2.0 port on your Control Hub. For teams with no or only one USB device, that's not a problem, just use the USB 3.0 port instead of the USB 2.0 port. If your team needs more than one device, such as a Expansion Hub over USB *and* a USB camera for object detection, it gets more complicated. To prevent shock, we have to get a USB hub, and connect all devices through just the USB 3.0 port.
+The best way to mitigate the problem is to not use the USB 2.0 port on your Control Hub. 
+For teams with no or only one USB device, that's not a problem, just use the USB 3.0 port instead of the USB 2.0 port. 
+If your team needs more than one device, such as an Expansion Hub over USB *and* a USB camera for object detection, it gets more complicated. 
+To prevent shock, you can get a USB hub and connect all devices through just the USB 3.0 port.
 
 
 
 
-*Last Updated: 2024-02-07*
+*Last Updated: 2024-05-29*

--- a/src/misc/terminology_and_acronyms.md
+++ b/src/misc/terminology_and_acronyms.md
@@ -5,7 +5,7 @@
 **EHub/ExHub**: Expansion Hub<br>
 **DS**: Driver Station<br>
 **RC**: Robot Controller<br>
-**ESD**: Electro-Static Discharge<br>
+**ESD**: Electrostatic Discharge<br>
 **DC**: Disconnect
 
 ## SDK Built-In

--- a/src/misc/why_kotlin/why_kotlin.md
+++ b/src/misc/why_kotlin/why_kotlin.md
@@ -15,19 +15,25 @@ FIRST provides official instructions for adding Kotlin to your project [here](ht
 
 ## The Recipe
 
-Kotlin is a language that makes a very solid attempt at modernising Java. It makes writing common Java patterns extremely concise, and makes it easy to write safer code, that is less likely to have strange bugs or throw null pointer exceptions that are hard to deal with.
+Kotlin is a language that makes a very solid attempt at modernising Java. 
+It makes writing common Java patterns extremely concise. 
+Kotlin also makes it easy to write safer code that is less likely to have strange bugs or throw confusing NullPointerExceptions.
 
-Kotlin is unlikely to be particularly useful to you if you are not using Object-Oriented aspects of Java already, if you are just writing \[Linear\]OpModes, but are not writing your own classes, Kotlin is probably not for you, while Kotlin certainly does offer some nice features in this environment, the challenges that come with using Kotlin may also prove hard to overcome unless you are writing more complex and involved code. It is also advisable not to try to switch to Kotlin at the same time as learning more Object-Oriented skills.
+Kotlin is unlikely to be particularly useful to you if you are not using Object-Oriented aspects of Java already.
+If you are just writing \[Linear\]OpModes, but are not writing your own classes, Kotlin is probably not for you. 
+While Kotlin certainly does offer some nice features in this environment, the challenges that come with using Kotlin may also prove hard to overcome unless you are writing more complex and involved code. 
+It is also advisable not to try to switch to Kotlin at the same time as learning more Object-Oriented skills.
 
-Due to Kotlin's concise nature, Kotlin can often prove difficult to read, where Java likes to put everything out in the open, and is very direct, Kotlin tends to imply much more.
+Due to Kotlin's concise nature, it can sometimes prove difficult to read. 
+Java likes to put everything out in the open and be very direct and specific, while Kotlin tends to imply much more.
 
-This recipe will cover some basics, but large parts of common Kotlin syntax, with direct comparisons to Java.
+This recipe will cover some basics of Kotlin syntax with direct comparisons to Java.
 
 ### Vars and Vals
 
-A big part of Kotlin is its changes to fields, getters, setters, and how they interact with paramaters from the constructor.
+A big part of Kotlin is its changes to fields, getters, setters, and how they interact with parameters from constructors.
 
-The following two snippets are equivalent (this is not quite true, but close enough, and gets the idea across):
+The following two snippets are effectively equivalent:
 
 ```kt
 {{#rustdoc_include VarsAndVals.kt:2:6}}
@@ -36,7 +42,8 @@ The following two snippets are equivalent (this is not quite true, but close eno
 ```java
 {{#rustdoc_include VarsAndVals.java:2:30}}
 ```
-Its pretty clear that Kotlin saves a lot of work on the front of writing getters and setters. While this isn't too big of a deal, after all, android studio offers some helpful tools to auto generate these functions in Java, Kotlin makes itself invaluable in enforcing the usage of these functions, in a syntactically shorter manner.
+It's pretty clear that Kotlin saves a lot of work on the front of writing getters and setters. 
+While this isn't too big of a deal, Kotlin makes itself invaluable in enforcing the usage of these functions in a syntactically shorter manner.
 
 ```kt
 {{#rustdoc_include VarsAndVals.kt:8:19}}
@@ -48,13 +55,17 @@ Its pretty clear that Kotlin saves a lot of work on the front of writing getters
 
 Kotlin enforces the use of getters and setters for property access, but uses the property access syntax!
 
-Already, our java code is ~2.5 times longer than Kotlin.
+Already, our Kotlin code is ~2.5 times shorter than Java.
 
-If you're worried about defining custom getters and setters, don't worry, Kotlin allows that too, but we won't cover it here. Kotlin allows for a fairly wide range of cool features around this concept.
+If you're worried about defining custom getters and setters, Kotlin allows that too.
+More detail is available in the [Kotlin docs](https://kotlinlang.org/docs/properties.html#getters-and-setters]
+Kotlin).
+Kotlin allows for a fairly wide range of cool features around this concept.
 
 ### Storing Constructor Parameters
 
-Kotlin makes it super easy and fast to take in constructor paramaters and store them in the class. The following two snippets are once again, equivalent:
+Kotlin makes it super easy to take in constructor parameters and store them in the class. 
+The following two snippets are also equivalent:
 
 ```kt
 {{#rustdoc_include ConstructorParams.kt}}
@@ -64,11 +75,13 @@ Kotlin makes it super easy and fast to take in constructor paramaters and store 
 {{#rustdoc_include ConstructorParams.java}}
 ```
 
-In this case, what was numerous lines in Java was only one in Kotlin, which is even a little easier to read!
+In this case, what was numerous lines in Java is only one in Kotlin. 
+The Kotlin version is even a little easier to read!
 
 ### Default Values In Methods and Constructors
 
-Kotlin makes it easy to specify default values to functions and constructors, again, the following two snippets are equivalent:
+Kotlin makes it easy to specify default values to functions and constructors.
+The following two snippets are equivalent:
 
 ```kt
 {{#rustdoc_include DefaultValues.kt}}
@@ -78,11 +91,11 @@ Kotlin makes it easy to specify default values to functions and constructors, ag
 {{#rustdoc_include DefaultValues.java}}
 ```
 
-Kotlin makes this a little more powerful than demonstrated here, but for most situations, this is pretty simple.
+Kotlin makes this a little more powerful than demonstrated here, but for most situations, this is pretty straightforward.
 
 ### Null Safety
 
-Kotlin makes it easy to work with values that can and can't be null, much easier than Java
+Kotlin makes it easy to work with values that can and can't be null, much easier than Java:
 
 ```kt
 val neverNull: Int = 10
@@ -90,7 +103,7 @@ val nullable: Int? = null
 ```
 The `?` lets us know that the variable could be null, and Kotlin will throw compilation warnings if we try to use it without checking and handling it.
 
-Lets look at some more:
+Some more examples:
 
 ```kt
 fun addOrThrow(a: Int?, b: Int?) {
@@ -100,9 +113,11 @@ fun addOrThrow(a: Int?, b: Int?) {
 }
 ```
 
-The `?:` operator is known as the Elvis operator, and means that the code after it gets run if the left hand side is null, which means that we know we exit early and throw an exception if either of our inputs are null
+The `?:` operator is known as the Elvis operator (after it's resemblance to Elvis Presley) and means that the code after it gets run only if the left-hand side is null.
+This allows the function to immediately exit and throw an error before any further processing occurs.
 
-The `!!` operator is like a shortcut for this operation in this situation, the Elvis operator is more powerful and flexible, if we don't want to throw our own error, and just want to crash, the `!!` operator basically insists that the value isn't null
+The `!!` operator is a shortcut for this operation. 
+The Elvis operator is more powerful and flexible, but if you don't want to throw a specific error and instead crash immediately, the `!!` operator will enforce that the value isn't null.
 
 Finally:
 
@@ -112,18 +127,24 @@ fun nullSafeMethodCall(a: Int?): Double {
 }
 ```
 
-We'll combine the concept above with the `?.` operator, which performs a null safe method call, if a is null, Kotlin won't try to call `.toDouble()` on it, and will just return null, which will then be caught by the Elvis operator!
+We'll combine the concept above with the `?.` operator, which performs a null safe method call. 
+If a is null, Kotlin won't try to call `.toDouble()` on it and will just return null, which will then be caught by the Elvis operator!
 
 ### Overview
 
-Kotlin has a lot more to it than this short overview, but these are some of the features that I find make a big common difference with Java, hopefully, this arms you with an expectation of what the rest of Kotlin is like, and some of the reasons that more advanced FTC programmers like to chose it over Java.
+Kotlin has a lot more to it than this short overview, but these are some of the features that make a big common difference with Java.
+Hopefully, this arms you with an expectation of what the rest of Kotlin is like, and some of the reasons that more advanced FTC programmers like to choose it over Java.
 
 [Kotlin official documentation](https://kotlinlang.org/docs/home.html)
 
-Overall, the best way to learn is just to jump in and give it a try, if you get stuck, search it up, or take a look at the [docs](https://kotlinlang.org/docs/home.html) again!
+Overall, the best way to learn is just to jump in and give it a try. 
+If you get stuck, search it up, or take a look at the [docs](https://kotlinlang.org/docs/home.html) again!
 
-If you feel like you need a complete example of using Kotlin for FTC, I advise you ask in the unoffical Discord. Most people who use Kotlin write fairly complex codebases, and use different combinations of libraries, so you might need to ask some questions in order to find an example that you can follow, and matches the libraries you plan to use.
+If you feel like you need a complete example of using Kotlin for FTC, I advise you ask in the FTC Discord. 
+Most people who use Kotlin write fairly complex codebases and use different combinations of libraries, so you might need to ask some questions to find an example relevant to you.
 
-Another good place to search for Kotlin code in an FTC context is in libraries. A good portion of FTC software libraries are written in Kotlin, so they may provide usage examples for Kotlin, or you may find reading their contents a good place to learn.
+Another good place to search for Kotlin code in an FTC context is in libraries. 
+Many FTC software libraries such as [Roadrunner](https://github.com/acmerobotics/road-runner) are written in Kotlin, so they can provide great usage examples. 
 
-*Last updated: 2024-01-30*
+
+*Last updated: 2024-05-29*

--- a/src/misc/why_kotlin/why_kotlin.md
+++ b/src/misc/why_kotlin/why_kotlin.md
@@ -58,8 +58,7 @@ Kotlin enforces the use of getters and setters for property access, but uses the
 Already, our Kotlin code is ~2.5 times shorter than Java.
 
 If you're worried about defining custom getters and setters, Kotlin allows that too.
-More detail is available in the [Kotlin docs](https://kotlinlang.org/docs/properties.html#getters-and-setters]
-Kotlin).
+More detail is available in the [Kotlin docs](https://kotlinlang.org/docs/properties.html#getters-and-setters).
 Kotlin allows for a fairly wide range of cool features around this concept.
 
 ### Storing Constructor Parameters

--- a/src/pidf_controllers/integrating_a_custom_PIDF_controller.md
+++ b/src/pidf_controllers/integrating_a_custom_PIDF_controller.md
@@ -1,12 +1,14 @@
 # Integrating a Custom PID(F) Controller
 
-*This recipe does not cover usage for Roadrunner or Command-Based structure.*
+*This recipe does not cover usage for Roadrunner or Command-Based structures.*
 
-[PID(F) controllers](https://www.ctrlaltftc.com/the-pid-controller) are some of the most used controllers in FTC. However, it can be confusing and difficult to properly integrate them into your OpModes. This recipe will go over an example of how to integrate a PID(F) controller alongside a manual control system.
+[PID(F) controllers](https://www.ctrlaltftc.com/the-pid-controller) are some of the most used controllers in FTC. 
+However, it can be confusing and challenging to properly integrate them into your OpModes.
+This recipe will go over an example of how to integrate a PID(F) controller alongside a manual control system.
 
 ## Ingredients
 
-1. A PID or PIDF controller class (this should be a file that is something like PIDFController.java, or you may use a premade one from a library like FTCLib).
+1. A PID or PIDF controller class (this should be a file that is something like PIDFController.java, or you may use a pre-made one from a library like FTCLib).
 2. A use case for the PID(F).
 3. An OpMode or LinearOpMode.
 
@@ -14,7 +16,8 @@
 
 ### Creating a PID(F) Controller
 
-The first part of using a PID(F) controller is creating one. In order to do this, we need to declare the PID(F) controller within the OpMode:
+The first part of using a PID(F) controller is creating one. 
+To do this, we need to declare the PID(F) controller within the OpMode:
 
 ```java
 package org.firstinspires.ftc.teamcode;
@@ -48,7 +51,11 @@ public class ExampleOpMode extends LinearOpMode {
 }
 ```
 
-Now that we have our PID(F) controller, we need to use it! One of the most common use cases for a PID(F) controller is moving a motor to a certain motor encoder position. As an example, let's say we had a linear slide and we want to move it to 500 ticks when we press "a", but otherwise we want to be able to move it up and down using the triggers. The following code is for a LinearOpMode (the `while (opModeIsActive())` section would go in the `loop()` function for a OpMode):
+Now that we have our PID(F) controller, we need to use it! 
+One of the most common use cases for a PID(F) controller is moving a motor to a certain motor encoder position.
+As an example, let's say we have a linear slide, and want to move it to 500 ticks when we press "a." 
+We also want to be able to move it up and down using the triggers. 
+The following code is for a LinearOpMode (the `while (opModeIsActive())` section would go in the `loop()` function for a OpMode):
 
 ```java
 
@@ -68,7 +75,7 @@ public void runOpMode() {
 
     while (opModeIsActive()) {
 
-        // Rising edge detector; runs if and only if "a" was pressed this loop.
+        // This is a rising-edge detector that runs if and only if "a" was pressed this loop.
         if (gamepad1.a && !lastGamepad1.a) {
             usePIDF = true;
         }
@@ -94,7 +101,8 @@ public void runOpMode() {
 
 ```
 
-This is a lot, so let's break it down piece by piece. First, we initialize our slide motor, which we call `slides`.
+This is a lot, so let's break it down piece by piece. 
+First, we initialize our slide motor, which we call `slides`.
 
 ```java
 DcMotor slides = hardwareMap.dcMotor.get("slides");
@@ -114,7 +122,10 @@ Gamepad lastGamepad1 = new Gamepad();
 Gamepad lastGamepad2 = new Gamepad();
 ```
 
-`targetPosition` is simply the position we want the slides to go to, which is 500. `usePIDF` stores the state of our system, i.e. whether we want to run the PIDF or use manual control. `lastGamepad1` and `lastGamepad2` are used for [Rising Edge Detectors](https://gm0.org/en/latest/docs/software/tutorials/gamepad.html?detector#rising-edge-detector). In short, they detect when a button is pressed, and ignore when it is held.
+`targetPosition` is simply the position we want the slides to go to, which is 500. 
+`usePIDF` stores the state of our system, i.e. whether we want to run the PIDF or use manual control. 
+`lastGamepad1` and `lastGamepad2` are used for [Rising Edge Detectors](https://gm0.org/en/latest/docs/software/tutorials/gamepad.html?detector#rising-edge-detector).
+In short, they detect when a button begins to be pressed, and ignore when it is held.
 
 The next part is the while loop, which ensures that the code runs in a loop until the OpMode stops.
 
@@ -122,18 +133,20 @@ The next part is the while loop, which ensures that the code runs in a loop unti
 while (opModeIsActive())
 ```
 
-We then use a [Rising Edge Detectors](https://gm0.org/en/latest/docs/software/tutorials/gamepad.html?detector#rising-edge-detector) to check if "a" was pressed. If it was, we set `usePIDF` to true in order to tell the program to move to the target position.
+We then use a [Rising Edge Detector](https://gm0.org/en/latest/docs/software/tutorials/gamepad.html?detector#rising-edge-detector) to check if "a" was just pressed.
+If it was, we set `usePIDF` to true to tell the program to move to the target position.
 
 ```java
-// Rising edge detector; runs if and only if "a" was pressed this loop.
+// This is a rising-edge detector that runs if and only if "a" was pressed this loop.
 if (gamepad1.a && !lastGamepad1.a) {
     usePIDF = true;
 }
 ```
 
-The next part is a little complicated, but the idea is that we only want to call `slide.setPower()` once, so we group all of the ways it can be called together so that they can't happen at the same time.
+The next part is a little complicated, but the idea is that we only want to call `slide.setPower()` once, so we group all the ways it can be called together so that they can't happen at the same time.
 
-First, we check if the left trigger is pressed. If it is, we set the slide power to an appropriate value and switch to manual control mode by setting `usePIDF` to `false`.
+First, we check if the left trigger is pressed. 
+If it is, we set the slide power to an appropriate value and switch to manual control mode by setting `usePIDF` to `false`.
 
 ```java
 if (gamepad1.left_trigger > 0) {
@@ -156,9 +169,10 @@ else if (gamepad1.right_trigger > 0) {
 }
 ```
 
-Note that we only run this code if the left trigger is not pressed, so even if we press both at the same time, there won't be any issues.
+Note that we use `else` to only run this code if the left trigger is not pressed. 
+This prevents pressing both triggers at the same time from causing any issues.
 
-**Tip:** If your triggers return nonzero values even when they are not being pressed, you can simply increase the minimum value (the `0` in the statement `if (gamepad1.left_trigger > 0)`) from `0` to something like `0.1`.
+**Tip:** If your triggers return nonzero values even when they are not being pressed, you can increase the minimum value (the `0` in the statement `if (gamepad1.left_trigger > 0)`) from `0` to something like `0.1`.
 
 Finally, if there are no manual inputs, and we are in the PID(F) state, we run the PID(F).
 
@@ -169,14 +183,20 @@ else if (usePIDF) {
 }
 ```
 
-This is a pretty standard way of using the PID(F) output to set a motor power. `slides.getCurrentPosition()`, as the name implies, just returns the current slide position, in ticks. The [*FTCLib*](https://ftclib.org/) PID(F) assumes that the first input of the function is the place where your motor is, and the second input is the place where your motor wants to be. We will be using the *FTCLib* PID(F) syntax here for the sake of having some standard, but either way works.
+This is a pretty standard way of using the PID(F) output to set a motor power. 
+`slides.getCurrentPosition()`, as the name implies, just returns the current slide position, in ticks.
+The [*FTCLib*](https://ftclib.org/) PID(F) assumes that the first input of the function is the place where your motor is, and the second input is the place where your motor wants to be.
+We will be using the *FTCLib* PID(F) syntax here for the sake of having some standard, but either way works.
 
-If you've read through this entire thing, then congrats! You should now have a fully functioning PID(F) controller that you can implement anywhere, even in conjunction with manual control.
+If you've read through this entire thing, then congrats! 
+You should now have a fully functioning PID(F) controller that you can implement anywhere, even in conjunction with manual control.
 
-Note that the example we went through is just one way PID(F)s can be used, and there are many ways to achieve this result. Don't worry if your code doesn't look exactly like mine!
+Note that the example we went through is just one way PID(F)s can be used, and there are many ways to achieve this result. 
+Don't worry if your code doesn't look exactly like this example!
 
-As an aside, the technique we used to make sure the PID(F) control and manual control did not interfere is a simple version of what's known as a [**Finite State Machine**](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html). This idea of having multiple possible states and only running one at a time to ensure they don't interfere can be used for much more complex systems, such as controlling an entire Autonomous!
+As an aside, the technique we used to make sure the PID(F) control and manual control did not interfere is a simple version of what's known as a [**Finite State Machine**](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html). 
+This idea of having multiple possible states and only running one at a time to ensure they don't interfere can be used for much more complex systems, such as controlling an entire Autonomous!
 
 Best of luck with your code!
 
-*Last updated: 2024-01-20*
+*Last updated: 2024-05-29*

--- a/src/pidf_controllers/syncing_two_linear_slide_motors_using_a_pidf_controller/syncing_two_linear_slide_motors_using_a_pidf_controller.md
+++ b/src/pidf_controllers/syncing_two_linear_slide_motors_using_a_pidf_controller/syncing_two_linear_slide_motors_using_a_pidf_controller.md
@@ -9,13 +9,21 @@
 
 ### The Problem
 
-Linear slides powered by two different motors can end up twisted, with one slide higher than the other. This can happen if the two encoders get out of sync. If you are using the RUN_TO_POSITION motor mode, this causes one slide to be supplied more power than the other and even if you are using a PIDF controller on each motor, the same problem would occur.
+Linear slides powered by two different motors can end up twisted, with one slide higher than the other. 
+This can happen if the two encoders get out of sync. 
+If you are using the RUN_TO_POSITION motor mode, this causes one slide to be supplied more power than the other. 
+Even if you are using a custom PID(F) controller on each motor, the same problem would occur.
 
 ### Methodology
 
-**The BEST way to keep these in sync is to have them be mechanically connected with a bar or a piece of channel. If the two act as one rigid body, then it is a lot less dependent on software. However, this is not always possible, hence the software solutions.**
+**The BEST way to keep these in sync is to have them be mechanically connected with a bar or a piece of channel. 
+If the two act as one rigid body, then it is a lot less dependent on software. 
+However, this is not always possible, hence the software solutions.**
 
-So, the way we're going to set this up is with a leader and a follower linear slide motor. This means we will use a PID(F) controller on one of the linear slide positions and just set that power to both motors. This resolves the issue of the two linear slides being supplied different powers. If both motors are going the same speed and both linear slides are well tensioned (whether it's belt or string) then the linear slides should stay synced.
+Instead, the way this recipe will explain is with a leader and a follower linear slide motor. 
+This means we will use a PID(F) controller on one of the linear slide positions and just set that power to both motors. 
+This resolves the issue of the two linear slides being supplied different powers.
+If both motors are going the same speed and both linear slides are well tensioned, the linear slides should stay synced.
 
 ### Code Example
 
@@ -25,6 +33,5 @@ This code example is going to assume you have a working PID(F) controller class 
 {{#rustdoc_include PIDFExample.java:3:29}}
 ```
 
-Hopefully this help!
 
-*Last Updated: 2024-01-25*
+*Last Updated: 2024-05-29*

--- a/src/roadrunner_056/how_to_integrate_a_PIDF_controller_with_roadrunner/how_to_integrate_a_PIDF_controller_with_roadrunner.md
+++ b/src/roadrunner_056/how_to_integrate_a_PIDF_controller_with_roadrunner/how_to_integrate_a_PIDF_controller_with_roadrunner.md
@@ -13,45 +13,64 @@
 
 ### PID(F) Controller and gains
 
-This recipes assumes you have 1) a PID(F) class that works and 2) tuned PID(F) gains. This recipe will not go over how to implement these and you should reference [integrating a custom PIDF controller](./how_to_integrate_a_PIDF_controller_with_roadrunner.md).
+This recipe assumes you have 1) a PID(F) class that works and 2) tuned PID(F) gains. 
+This recipe will not go over how to implement these; you should reference [integrating a custom PIDF controller](./how_to_integrate_a_PIDF_controller_with_roadrunner.md).
 
 ### Finite State Machines
 
-For a more indepth understanding of what finite state machines are, visit [gm0](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html?highlight=finite). In short, a finite state machine is a code structure which allows code to run linearly while also having quasi-parallel actions running. The example we will be working with today is driving with Roadrunner while controlling linear slides.
+In short, a finite state machine is a code structure which allows code to run linearly while also having quasi-parallel actions running.
+The example we will be working with today is driving with Roadrunner while controlling linear slides.
+For a more indepth understanding of what finite state machines are, visit [gm0](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html?highlight=finite).
 
-You can work with Finite State Machines in either a LinearOpMode or an OpMode, either works. For the purpose of this recipe, we will be using a LinearOpMode. To use an OpMode you can move everything before the while loop can go in init and everything in the while loop into the `loop()` function.
+You can work with Finite State Machines in either a LinearOpMode or an OpMode, either work. 
+For this recipe, we will be using a LinearOpMode.
+To use an OpMode, move everything before the while loop into the `init()` function and everything in the while loop into the `loop()` function.
 
 We will first have a full example and then break it down piece by piece.
 
-*This example is more like pseudo code than real code and is meant to demonstrate a methodology.*
+*This example is more like pseudocode than real code and is meant to demonstrate a methodology.*
 
 ```java
 {{#rustdoc_include RoadRunnerPIDF.java::}}
 ```
 
-Okay, let's break this down piece by piece. First, what is an "enum" and why do we use them? Enums are a way to define a set of named constant values. They provide a convenient and readable way to work with predefined, named values in your code. Here, we used an enum to describe the various states the robot could be in.
+Okay, let's break this down piece by piece.
+First, what is an "enum" and why do we use them? 
+Enums are a way to define a set of named constant values. 
+They provide a convenient and readable way to work with predefined, named values in your code. 
+Here, we used an enum to describe the various states the robot could be in.
 
 ```java
 {{#rustdoc_include RoadRunnerPIDF.java:3:9}}
 ```
 
-By using names with meaning like these, it is much clearer when writing and reading the code what each block does. It also means we don't have to remember that state 0 means START and state 1 means DRIVE_FORWARD, etc....
+By using names with meaning like these, it is much clearer when writing and reading the code what each block does. 
+It also means we don't have to remember that state 0 means START and state 1 means DRIVE_FORWARD, etc.
 
-Next we initialize all our stuff and build our trajectories. The important one to note is creating `strafeLeft`, which includes slide movement.
+Next, we initialize everything and build our trajectories.
+The important one to note is creating `strafeLeft`, which includes slide movement.
 
 ```java
 {{#rustdoc_include RoadRunnerPIDF.java:38:43}}
 ```
 
-We used a displacement marker, which says "right here do this thing." The `() -> {}` is just fancy notation for a one time use function. The empty paranthesis says "this doesn't require any arguments to be passed into the function" and the curly braces denote the start of the function. In this case, we're just setting a variable `targetPosition`, but this marker could include setting servo position, reading sensors, or anything else really.
+We used a displacement marker, which tells Roadrunner to run this code at the specified position along the trajectory.
+The `() -> {}` is the lambda format for a one time use function. 
+The empty parentheses indicate that the function requires no arguments, and the curly braces denote the start of the function.
+In this case, we're just setting the `targetPosition` variable, but this marker could include setting servo position, reading sensors, or anything else really.
 
 ```java
 {{#rustdoc_include RoadRunnerPIDF.java:57:66}}
 ```
 
-So now we're getting to the Finite State Machine (FSM) part. The first part of this case, which you'll see in each part, is checking whether previous and current states are equal. This allows us to run code the first time it enters this state, like starting a trajectory (in this example). Then inside that same block, we also need to set the previous state to the one we're in.
+So now we're getting to the Finite State Machine (FSM) part. 
+The first part of this case, which you'll see in each part, is checking whether previous and current states are equal. 
+This allows us to run code the first time it enters this state, like starting a trajectory (in this example). 
+Then inside that same block, we also need to set the previous state to the one we're in.
 
-The else if just checks if we're done with this state so it knows when to move on. This is the transition trigger, in this case, finishing the roadrunner trajectory.
+The `else if` just checks if we're done with this state to detect when to move on. 
+This is the transition trigger.
+In this case, it detects when the Roadrunner trajectory finishes.
 
 The next case is the more interesting one.
 
@@ -59,30 +78,41 @@ The next case is the more interesting one.
 {{#rustdoc_include RoadRunnerPIDF.java:67:74}}
 ```
 
-Here we have the same structure. However, this time our transition trigger is finishing the roadrunner trajectory and the linear slides reaching their target. Because this runs in a loop, once the displacement marker in the trajectory sequence triggers and changes the targetPosition, the PID update that runs at the end of every loop will start setting the power of the linear slides to reach that target.
+Here we have the same structure. 
+However, this time our transition trigger is finishing the Roadrunner trajectory and the linear slides reaching their target.
+Because this runs in a loop, once the displacement marker triggers and changes the targetPosition, the PID update that runs at the end of every loop will move the linear slides accordingly.
 
-It is also important to note that when using async following, you must call drive.update() once every loop. This tells the path follower the updated location of the robot so it can be as accurate as possible.
+It is also important to note that when using async following, you must call drive.update() once every loop. 
+This allows Roadrunner to track the robot's movement and to ensure the motors are following the trajectory.
+Without it, the robot will not move.
 
-Whew! You should now be able to integrate a PID(F) controller with roadrunner trajectories.
+Whew! You should now be able to integrate a PID(F) controller with Roadrunner trajectories.
 
-This example was meant to be general and explain the structure and concepts needed to make PID(F) controllers work with roadrunner. It will almost certainly require changes to make it work exactly how you wish, so don't worry if your code doesn't look exactly like this example!
+This example was meant to be general and explain the structure and concepts needed to make PID(F) controllers work with Roadrunner. 
+It will almost certainly require changes to make it work exactly how you wish, so don't worry if your code doesn't look exactly like this example!
 
 ### State Factory
 
-[State Factory](https://state-factory.gitbook.io/state-factory/installation) is a library which helps abstract a lot of the code of a finite state machine. It also helps ensure you don't forget to write a break or an exit case.
+[State Factory](https://state-factory.gitbook.io/state-factory/installation) is a library which helps abstract a lot of the code of a finite state machine. 
+It also helps ensure you don't forget to write a break or an exit case.
 
-*This recipe will not cover the installation of State Factory, please follow the instructions on the gitbook to install*
+*This recipe will not cover the installation of State Factory. 
+Please follow the instructions on their gitbook to install it.*
 
-So, we're going to write the same fintie state machine, but using state factory.
+So, we're going to write the same finite state machine but this time using State Factory.
 
 ```java
 {{#rustdoc_include RoadRunnerPIDFSF.java::}}
 ```
 
-These two example both do the exact same thing and this introduction to State Factory was mostly meant to show how it can make writing FSMs less painful.
+These two examples both do the exact same thing.
+This introduction to State Factory was mostly meant to show how it can simplify writing FSMs.
 
-Android studio may recommend changing something like `() -> !drive.isBusy()` to `!drive::isBusy`, these are simply two different ways to write the same thing. The double colon works like `class/instance::method`.
+Android studio may recommend changing something like `() -> !drive.isBusy()` to `!drive::isBusy`. 
+These are simply two different ways to write the same thing. 
+The double colon works like `class/instance::method`.
 
-**I think it is important to note that these were extremely simple FSMs and do not demonstrate their full capabilities. This was simply meant to show you a way to integrate RoadRunner and a PIDF controller.**
+**It is important to note that these were extremely simple FSMs and do not demonstrate their full capabilities. 
+This was simply meant to show you a way to integrate RoadRunner and a PIDF controller.**
 
 *Last Updated: 2024-01-23*

--- a/src/roadrunner_056/is_the_bump_on_manual_feedforward_tuner_normal.md
+++ b/src/roadrunner_056/is_the_bump_on_manual_feedforward_tuner_normal.md
@@ -1,7 +1,10 @@
 # Is the Bump On Manual Feedforward Tuner Normal?
 
-![image of decelleration bump](../static/is_the_bump_on_manual_feedforward_tuner_normal/deceleration_bump.png)
+![image of deceleration bump](../static/is_the_bump_on_manual_feedforward_tuner_normal/deceleration_bump.png)
 
-Yes! The bump when acceleration and decelerating are normal. It's just wonky control hub / expansion hub stuff where it's not good at that. There's nothing you can do about so just try to get the plateus and slopes to match up.
+Yes! 
+The bump when accelerating and decelerating is normal. 
+It is caused by a fundamental hardware issue with the Control and Expansion Hubs that makes deceleration weird.
+There's nothing you can do about it; just try to get the plates and slopes to match up as closely as possible.
 
-*Last Updated: 2024-01-21*
+*Last Updated: 2024-05-29*

--- a/src/roadrunner_056/manual_feed_forward_tuner_opposite_velocities.md
+++ b/src/roadrunner_056/manual_feed_forward_tuner_opposite_velocities.md
@@ -1,6 +1,7 @@
-# Target Velocity is Positive When Measured Velocity is Negative and Vice Versa When Tuning Manual Feedforward
+# Target Velocity is Positive When Measured Velocity is Negative When Tuning Manual Feedforward
 
-If MotorDirectionDebugger works perfectly, this simply means that either your right side encoders are plugged in to the wrong ports(so swap `frontRight` and `backRight` encoder cables) or your left side encoders are plugged in to the wrong ports(so swap `frontLeft` and `backLeft` encoder cables). An easy way to debug this is to add a `printEncoderValues` telemetry method in `SampleMecanumDrive`.
+If MotorDirectionDebugger works perfectly, this means that either your right side encoders are plugged in to the wrong ports (so swap `frontRight` and `backRight` encoder cables) or your left side encoders are plugged in to the wrong ports (so swap `frontLeft` and `backLeft` encoder cables). 
+An easy way to debug this is to add a `printEncoderValues` telemetry method in `SampleMecanumDrive`.
 
 ```java
 public void printEncoderValues(Telemetry telemetry) {
@@ -17,4 +18,4 @@ drive.printEncoderValues(telemetry);
 
 
 
-*Last updated: 2024-01-20*
+*Last updated: 2024-05-30*

--- a/src/roadrunner_056/manual_feedforward_tuner_overshooots.md
+++ b/src/roadrunner_056/manual_feedforward_tuner_overshooots.md
@@ -1,5 +1,10 @@
 # Manual Feedforward Tuner Overshoots
 
-This is normal! The REV hub's motor controller are not great at decelerating, so this typically causes about a 10% overshoot on manual feedforward tuner. It's okay to move on the the next tuning steps. However, when you get to the feedback tuning, whether it's "back and forth" or "followerPIDTuner", you will want to add a non-zero kd term. This will help the robot not overshoot.
+This is normal! 
+The REV hub motor controllers are not great at decelerating, so this typically causes about a 10% overshoot on manual feedforward tuner. 
+It is okay to move on to the next tuning steps. 
 
-*Last Updated: 2024-01-20*
+However, when you get to the feedback tuning, whether it's "Back and Forth" or "FollowerPIDTuner," you will want to add a non-zero kD term. 
+This will help the robot not overshoot.
+
+*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_drifts_to_one_side_during_manual_feedforward_tuning.md
+++ b/src/roadrunner_056/robot_drifts_to_one_side_during_manual_feedforward_tuning.md
@@ -1,5 +1,9 @@
 # Robot Drifts to One Side During Manual Feedforward Tuning
 
-If this happens, you shouldn't worry. This can be caused by an unbalanced robot or one wheel having slightly more friction than the others. Whatever the reason, this will be corrected for in the later tuning steps so you can safely ignore this drift.
+If this happens, you shouldn't worry. 
+This can be caused by many reasons, such as an unbalanced robot or one wheel having slightly more friction than the others. 
 
-*Last Updated: 2024-01-20*
+Whatever the reason, this will be corrected for in the later tuning steps.
+It can safely be ignored.
+
+*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_drifts_while_tuning_follower_pid.md
+++ b/src/roadrunner_056/robot_drifts_while_tuning_follower_pid.md
@@ -1,7 +1,10 @@
 # Robot Drifts While Tuning Follower PID
 
 ### Check Localization
-Run `LocalizationTest` and drive the robot back and forth a few times. You want to ensure that the behavior shown on the dashboard mirrors that of what you can see. If the robot was veering in `BackAndForth`, see if the dashboard bot is veering the same. If you notice the same discrepancy while doing running localization test, it means the problem is in your localization.
+Run `LocalizationTest` and drive the robot back and forth a few times. 
+You want to ensure that the behavior shown on the dashboard mirrors that of what you can see. 
+If the robot was veering in `BackAndForth`, see if the dashboard bot is veering the same.
+If you notice the same discrepancy while running `LocalizationTest`, it means the problem is in your localization.
 
 ### Tuning PID
 If you're certain that localization works fine and the robot "knows" that it's wrong, but isn't correcting, then you need to tune your PID values more.

--- a/src/roadrunner_056/robot_drives_full_speed_on_start_when_following_trajectory.md
+++ b/src/roadrunner_056/robot_drives_full_speed_on_start_when_following_trajectory.md
@@ -1,8 +1,10 @@
 # Robot Drive Full Speed on Start When Following Trajectory
 
-If you are running an op mode that has roadrunner trajectories in it, and when you start moving it goes at full speed right away, this almost always means you forgot to set a pose estimate. In `init()` before you run any trajectories, make sure you have `sampleMecanumDrive.setPoseEstimate(startingPose)`, whatever your starting pose may be. Also make sure that the trajectory starting pose matches this. Like
+If you are running an OpMode that has Roadrunner trajectories in it, and when you start moving it goes at full speed right away, this almost always means you forgot to set a pose estimate.
+In `init()`, before you run any trajectories, make sure you have `drive.setPoseEstimate(startingPose)`, whatever your starting pose may be. 
+Make sure that the trajectory starting pose matches this:
 ```java
-Trajectory traj = sampleMecanumDrive.trajectoryBuilder(startingPose)
+Trajectory traj = drive.trajectoryBuilder(startingPose)
     ...
     .build();
 ```

--- a/src/roadrunner_056/robot_localization_makes_circle_when_spinning_in_place.md
+++ b/src/roadrunner_056/robot_localization_makes_circle_when_spinning_in_place.md
@@ -1,14 +1,21 @@
 # Robot Localization Makes Circle When Spinning In Place
 
-So when you spin the robot in place the drawing on dashboard is making a circle. This is normal and can be fixed.
+So when you spin the robot in place, the drawing on FTC Dashboard is making a circle. 
+This is normal and can be fixed.
 
 ### What causes it?
-When the robot is spun, the strafing tracking wheel moves, which makes the localization think the robot moved in a circle. This can be counteracted with math (which RR luckily has) by figuring out the forward distance from the strafing tracking wheel to the center of rotation.
+When the robot is spun, the strafing odometry wheel moves which makes the localization think the robot moved in a circle. 
+This can be counteracted using the forward distance from the strafing tracking wheel to the center of rotation.
 
-### 3 Wheel Solution
-For 3 wheel odometry, this means your forward offset isn't tuned correctly. Run the tuner and replace the value. If that doesn't work, check whether the strafing pod is closer to the front or the back of the robot. If it's closer to the back, the offset should be negative.
+### Three Wheel Solution
+For three wheel odometry, this means your forward offset isn't tuned correctly. 
+Run the tuner and replace the value. 
+If that doesn't work, check whether the strafing pod is closer to the front or the back of the robot. 
+If it's closer to the back, the offset should be negative.
 
-### 2 Wheel Solution
-The solution for 2 wheel odometry is largely the same. Instead of being called forward offset, it is the x and y position of the strafing pod. The same advice about positive and negative still applies.
+### Two Wheel Solution
+The solution for two wheel odometry is largely the same. 
+Instead of the forward offset, you must tune the x and y position of the strafing pod. 
+The same advice about positive and negative offset still applies.
 
-*Last Updated: 2024-01-21*
+*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_velocity_plateaus_below_target_velocity_plateau.md
+++ b/src/roadrunner_056/robot_velocity_plateaus_below_target_velocity_plateau.md
@@ -2,6 +2,8 @@
 
 ![image of robot velocity not reaching max target velocity](../static/robot_velocity_plateaus_below_target_velocity_plateau/lowPlateau.png)
 
-Okay, so this means you've reached your robot's actual max velocity. You should lower the max velocity specified in DriveConstants. Run the MaxVelocityTuner to find the recommended max velocity to use.
+This means you've reached your robot's actual max velocity.
+You should lower the max velocity specified in DriveConstants.
+Run the MaxVelocityTuner to find the recommended max velocity to use.
 
 *Last Updated: 2024-02-08*

--- a/src/roadrunner_10/null_list_error_in_rr_10.md
+++ b/src/roadrunner_10/null_list_error_in_rr_10.md
@@ -13,7 +13,8 @@
 If you have gotten through Road Runner 1.0 tuning to the ForwardRampLogger tuning step (you may also see this in LateralRampLogger or AngularRampLogger), sometimes you will get an empty list error when you press the "latest" button.
 
 ### Solution
-This is a pretty normal error to see, as the Road Runner docs do not state how to perform this test very well. You must first run the OpMode from the rc, let it finish, and then open the list on your RC network as the Road Runner docs say.
+You must first run the OpMode from the Driver Station and then stop it once the robot's speed stops increasing.
+Finally, you can open the tuning page on your robot's Wi-Fi network, as the Road Runner docs say.
 
 
-*last Updated: 2024-02-08*
+*last Updated: 2024-05-29*


### PR DESCRIPTION
I felt like a lot of the information here could be phrased more simply or explained differently, so this PR does that.

I also separated sentences onto their own lines, which makes no visual difference (markdown ignores it) but makes them easier to edit and easier for Git to process.