### PR TITLE
Add mdbook-blame preprocessor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # To push a branch 
+      contents: write  # To push a branch
       pull-requests: write  # To create a PR from that branch
     steps:
     - uses: actions/checkout@v4
@@ -21,6 +21,13 @@ jobs:
         mkdir mdbook
         curl -sSL $url | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
+    - name: Install latest mdbook-blame
+      run: |
+        tag=$(curl 'https://api.github.com/repos/Froze-N-Milk/mdbook-blame/releases/latest' | jq -r '.tag_name')
+        url="https://github.com/Froze-N-Milk/mdbook-blame/download/${tag}/mdbook-blame-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+        mkdir mdbook-blame
+        curl -sSL $url | tar -xz --directory=./mdbook-blame
+        echo `pwd`/mdbook-blame >> $GITHUB_PATH
     - name: Deploy GitHub Pages
       run: |
         # This assumes your book is in the root of your repository.

--- a/book.toml
+++ b/book.toml
@@ -5,6 +5,9 @@ multilingual = false
 src = "src"
 title = "The Cookbook"
 
+[preprocessor.blame]
+source = "https://github.com/dr-hextanium/cookbook/commit/"
+
 [output.html.code.hidelines]
 java = "# "
 kt = "# "

--- a/src/electrical/how_to_wire_odometry_pods.md
+++ b/src/electrical/how_to_wire_odometry_pods.md
@@ -5,32 +5,27 @@
 
 1. An Expansion Hub or Control Hub
 2. either 2 or 3 odometry pods/modules
-     
+
 ## The Recipe
 
 ### The problem
-The Rev Control Hub and Expansion Hub, as found [here](https://blog.eeshwark.com/robotblog/rev-hub-quadrature) by 7244 alum Eeshwar, only have 2 reliable quadrature encoder ports. 
+The Rev Control Hub and Expansion Hub, as found [here](https://blog.eeshwark.com/robotblog/rev-hub-quadrature) by 7244 alum Eeshwar, only have 2 reliable quadrature encoder ports.
 This means high CPR/PPR encoders such as the Rev Through Bore encoder will miss counts on ports 1 and 2 which will lead to drift.
 
 
 ### Solutions
 ### 2 Wheel Odometry
-For teams that use a 2 wheel + IMU setup, the solution is simple! 
-Put the drive motors on the Control Hub. 
+For teams that use a 2 wheel + IMU setup, the solution is simple!
+Put the drive motors on the Control Hub.
 Then, as you don't need drive encoders, you can simply put the odometry on Control Hub encoder ports 0 and 3 where you would usually put the motor encoders.
 
 ### 3 Wheel Odometry
-For teams with 3 wheel odometry, it is a bit more complex. 
+For teams with 3 wheel odometry, it is a bit more complex.
 The most important odometry pods are the parallel ones since encoder drift with them will cause heading drift.
-This can rapidly ruin your localization as heading is used as a basis for all other measurements. 
-Since they're the most important, the parallel pods should go in ports 0 and 3 on the Control Hub. 
+This can rapidly ruin your localization as heading is used as a basis for all other measurements.
+Since they're the most important, the parallel pods should go in ports 0 and 3 on the Control Hub.
 The perpendicular (strafe) pod is less important to localization, so it is fine to put it in port 1 or 2 on the Control Hub.
 
 Note that you should always put odometry on the Control Hub (or at least all on the same hub) even if you must place it in ports 1 or 2.
 This is because reading from the Expansion Hub requires an additional bulk read.
 This can greatly worsen loop times and is not worth the benefits of using the 0 and 3 ports.
-
-
-
-
-*Last Updated: 2024-05-29*

--- a/src/electrical/why_we_should_only_use_usb_30.md
+++ b/src/electrical/why_we_should_only_use_usb_30.md
@@ -21,12 +21,7 @@ This provides a path for a static shock to the USB device to cause a Wi-Fi disco
 
 
 ### How to Mitigate the Problem
-The best way to mitigate the problem is to not use the USB 2.0 port on your Control Hub. 
-For teams with no or only one USB device, that's not a problem, just use the USB 3.0 port instead of the USB 2.0 port. 
-If your team needs more than one device, such as an Expansion Hub over USB *and* a USB camera for object detection, it gets more complicated. 
+The best way to mitigate the problem is to not use the USB 2.0 port on your Control Hub.
+For teams with no or only one USB device, that's not a problem, just use the USB 3.0 port instead of the USB 2.0 port.
+If your team needs more than one device, such as an Expansion Hub over USB *and* a USB camera for object detection, it gets more complicated.
 To prevent shock, you can get a USB hub and connect all devices through just the USB 3.0 port.
-
-
-
-
-*Last Updated: 2024-05-29*

--- a/src/improving_loop_times/improving_loop_times.md
+++ b/src/improving_loop_times/improving_loop_times.md
@@ -76,5 +76,3 @@ This example uses [CachingHardware](https://github.com/Dairy-Foundation/CachingH
 ```java
 {{#rustdoc_include CachingOptimizedOpMode.java:12:}}
 ```
-
-*Last Updated: 2024-10-14*

--- a/src/intro_to_programming/intro_to_git.md
+++ b/src/intro_to_programming/intro_to_git.md
@@ -10,8 +10,8 @@ If you are instead using the RoadRunner quickstart or similar, use that in place
 ### Git vs GitHub
 **Git** is a version control system that tracks changes in code over time, allowing you to collaborate effectively.
 **GitHub** is a platform that hosts Git repositories.
-Though there are many Git hosting platforms, including GitLab and Bitbucket, 
-this guide focuses on GitHub because it is the easiest to use with the FTC SDK. 
+Though there are many Git hosting platforms, including GitLab and Bitbucket,
+this guide focuses on GitHub because it is the easiest to use with the FTC SDK.
 
 ## Ingredients
 1. Internet access
@@ -19,29 +19,29 @@ this guide focuses on GitHub because it is the easiest to use with the FTC SDK.
 3. Android Studio
 4. A [GitHub](https://github.com/) account and organization.
     - To create an account, follow the steps on [GitHub](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github).
-    - While creating an organization is optional, it is highly recommended for FTC teams. 
-    Follow the directions on [GitHub](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch). 
-    - Note that user accounts can only create one fork of a repository, while organization accounts can create multiple. 
-   This makes it easier for your team to set up a repository for each season. 
+    - While creating an organization is optional, it is highly recommended for FTC teams.
+    Follow the directions on [GitHub](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch).
+    - Note that user accounts can only create one fork of a repository, while organization accounts can create multiple.
+   This makes it easier for your team to set up a repository for each season.
 
 ## Recipe
 ### 0. Installing Git
 The easiest way to install Git on your device is
-to download it from [Git's download page](https://git-scm.com/downloads). 
+to download it from [Git's download page](https://git-scm.com/downloads).
 Select your operating system and follow the instructions on the website.
 
-### 1. Forking the Repository 
+### 1. Forking the Repository
 This step only needs to be done once each season.
 
-> A Fork on GitHub is a copy of another repository on GitHub from one account to another account. 
+> A Fork on GitHub is a copy of another repository on GitHub from one account to another account.
 > The new forked repository retains a parent-child relationship with the origin repository.
-> Forks are typically used when software will have an independent line of development, 
+> Forks are typically used when software will have an independent line of development,
 > such as when FTC teams develop their own team code
 > using the FIRST-Tech-Challenge/FtcRobotController repository as a basis.
-> FTC teams should create a Fork of the FIRST-Tech-Challenge/FtcRobotController repository as a convenient way 
+> FTC teams should create a Fork of the FIRST-Tech-Challenge/FtcRobotController repository as a convenient way
 > to manage their software development process.
 > Thanks to the parent-child relationship,
-> when changes are made to the parent repository 
+> when changes are made to the parent repository
 > those changes can be easily tracked and fetched/merged into the forked repository,
 > keeping the forked repository up to date.
 -  The FIRST Tech Challenge documentation
@@ -51,7 +51,7 @@ The FtcRobotController repo is the Software Development Kit (SDK)
 provided by FIRST that allows you to write your own robot code.
 
 Once you have opened the repo, click the `Fork` button in the upper-right-hand corner.
-That will bring you to a page that looks like this: 
+That will bring you to a page that looks like this:
 
 ![The fork page](../static/intro_to_git/fork.png)
 
@@ -59,7 +59,7 @@ Under the `Owner` dropdown, select your organization (if you elected to create o
 as opposed to your individual user account.
 Under `Repository name`, I recommend naming your repo after the current FTC season name
 (such as Into The Deep or CenterStage), or by the year (such as 2024).
-Finally, press `Create fork` to create your own copy of the SDK repository. 
+Finally, press `Create fork` to create your own copy of the SDK repository.
 
 #### 1.5 Logging into GitHub on Android Studio
 First, open your [GitHub token settings](https://github.com/settings/tokens),
@@ -68,29 +68,29 @@ Press `Generate new token (classic)` at the top and that will take you to a page
 
 ![The token generation page](../static/intro_to_git/personal_access_token.png)
 
-For `Note`, write the use case of the token, such as "Android Studio." 
-For `Expiration`, select `No expiration`, which may cause GitHub to warn you. 
+For `Note`, write the use case of the token, such as "Android Studio."
+For `Expiration`, select `No expiration`, which may cause GitHub to warn you.
 For `Select scopes`, select `repo`, `workflow`, `read:org`, and `gist`.
 Finally, click `Generate token` and copy it.
 
-Now open Android Studio. 
+Now open Android Studio.
 Open your settings (under `File` then `Settings`)
-and then go to `Version Control` -> `GitHub`. 
+and then go to `Version Control` -> `GitHub`.
 In the top left corner of the box, press the `+` icon and `Log in with token...`,
 and paste in the token you just generated.
 
 ### 2. Opening Your Fork in Android Studio
 This step needs to be done by everyone who intends on programming for your team.
 
-First, at the top right of your new repository, press the green `Code` button. 
+First, at the top right of your new repository, press the green `Code` button.
 Under that tab, copy the HTTP url of your repo.
 
-Next, open Android Studio and navigate to the `New Project from Version Control` menu. 
+Next, open Android Studio and navigate to the `New Project from Version Control` menu.
 To do that, do `File` -> `New` -> `Project from Version Control`, which should bring you to a menu that looks like this:
 
 ![Get from VCS menu](../static/intro_to_git/get_from_vcs.png)
 
-For the URL, paste in the link that you just copied from your repo, then press `Clone`. 
+For the URL, paste in the link that you just copied from your repo, then press `Clone`.
 Android Studio will then download your project and build it through Gradle, which may take a few minutes;
 you can monitor this process using the progress bar in the bottom right.
 
@@ -102,13 +102,13 @@ and you can start coding as normal.
 Now that you've made some changes,
 you should create a *commit* to snapshot your changes and *push* (upload) them to GitHub.
 To do this, press the button on the left side that looks like a line with a circle on it
-(just like the circles in the above image) to open the Commit menu in Android Studio. 
+(just like the circles in the above image) to open the Commit menu in Android Studio.
 That will look like this:
 
 ![The commit menu](../static/intro_to_git/commit%20menu.png)
 
-The `Changes` section will show the files you have edited. 
-Select the files you want to commit by clicking on the checkbox next to them, 
+The `Changes` section will show the files you have edited.
+Select the files you want to commit by clicking on the checkbox next to them,
 or use the checkbox in the top left to select all of them.
 
 Finally, write a commit message in the box in the lower portion of the menu to describe what you've changed.
@@ -118,7 +118,7 @@ so that's what I wrote in my commit message.
 Once you're done,
 press `Commit and Push...` which will commit your changes and push them to GitHub's copy of your repository.
 
-In some situations (such as when you are offline, or when a push fails), 
+In some situations (such as when you are offline, or when a push fails),
 you may also prefer to just hit the `Commit` button to save an offline snapshot of your changes,
 and then later click your branch title in the top right, which displays the following options:
 
@@ -137,11 +137,11 @@ This will ask you whether you want to Merge or to Rebase the incoming changes.
 Merging is simpler, so we will explain it here; select it and hit OK.
 
 Most of the time that will be all that is necessary to download all the incoming changes, and
-you will immediately be able to resume coding. 
+you will immediately be able to resume coding.
 However, occasionally when multiple people edit the same file at the same time, a Merge Conflict can occur.
 This can appear as a Conflict pop up as shown below.
 
-![The Conflict pop up](../static/intro_to_git/merge_conflicts_dialog_dark.png) 
+![The Conflict pop up](../static/intro_to_git/merge_conflicts_dialog_dark.png)
 
 See the [official JetBrains documentation](https://www.jetbrains.com/help/idea/resolve-conflicts.html)
 for what to do in this scenario.
@@ -161,7 +161,7 @@ Next, the first time you update, run this command in the terminal:
 This will add the FIRST SDK as a remote repository named `sdk`.
 You will only have to do this once.
 
-Next, each time you want to update, run this command: `git pull sdk master --no-rebase` 
+Next, each time you want to update, run this command: `git pull sdk master --no-rebase`
 This will pull the changes from the `master` branch of the `sdk` remote repository.
 We use `--no-rebase` here to ensure that we merge instead of rebasing.
 
@@ -211,6 +211,3 @@ for information on how to resolve them, if they occur.
 Once any conflicts are resolved,
 and you are ready to merge the branches (potentially after getting approval from your team),
 select the `Merge pull request` button to accept the pull request.
-
-*Last updated: 2024-10-06*
-

--- a/src/intro_to_programming/setup.md
+++ b/src/intro_to_programming/setup.md
@@ -23,8 +23,8 @@ Access to **Admin Permissions** on aforementioned computer.<br>
     - Open [Android Studio](https://developer.android.com/studio/). <br>
       <br>
 3. **Download and Open [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController)**:
-    - In the [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController) GitHub repository, press the blue **code** button and press [download zip](https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/heads/master.zip). 
-      - You can alternatively use [Github Desktop](https://desktop.github.com/) to open [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController) in [Android Studio](https://developer.android.com/studio/), which is not covered in this Recipe.  
+    - In the [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController) GitHub repository, press the blue **code** button and press [download zip](https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/heads/master.zip).
+      - You can alternatively use [Github Desktop](https://desktop.github.com/) to open [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController) in [Android Studio](https://developer.android.com/studio/), which is not covered in this Recipe.
     - Extract the contents of the zip file to a folder (typically in your Downloads or Documents folder).
     - In [Android Studio](https://developer.android.com/studio/), press File &rarr; Open (⌘ + O on Mac or Win + O on Windows).
     - Select the folder you extracted the zip file to, and press open. **DO NOT** open any folder inside the extracted folder.
@@ -47,11 +47,11 @@ Access to **Admin Permissions** on aforementioned computer.<br>
         - **Mac**: <br>
           - Option 1 - Using [Homebrew](https://brew.sh/) (Highly Recommended) <br>
             [Homebrew](https://brew.sh/) is a package manager for Mac. This is the easiest way and will provide automatic updates.
-            - Install the [Homebrew](https://brew.sh/) package manager by running the following command in a terminal:  
+            - Install the [Homebrew](https://brew.sh/) package manager by running the following command in a terminal:
             ```bash
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
               ```
-            
+
             - Then, run this command to install [ADB](https://developer.android.com/studio/releases/platform-tools) using [Homebrew](https://brew.sh/):
             ```bash
             brew install android-platform-tools
@@ -74,7 +74,7 @@ Access to **Admin Permissions** on aforementioned computer.<br>
             ```bash
             source ~/.bash_profile
               ```
-        - **Linux**: 
+        - **Linux**:
           <br>[ADB](https://developer.android.com/studio/releases/platform-tools) should already be installed by default with the installation of Android Studio. If not, you can use the following steps below to install [ADB](https://developer.android.com/studio/releases/platform-tools) manually:<br>
           <br>
           - Open a terminal window and run the following command:
@@ -100,4 +100,3 @@ Congratulations! You have successfully installed the necessary software to progr
 
 ## Troubleshooting
 - If you have questions/issues with the installation process, the [Unofficial FTC Discord](https://discord.gg/first-tech-challenge) has many experienced programmers who can help you with all sorts of issues, including installation issues.
-- *Last Updated: 2024-05-30*

--- a/src/misc/pedro_vs_roadrunner.md
+++ b/src/misc/pedro_vs_roadrunner.md
@@ -2,7 +2,7 @@
 
 **Pedro Pathing** is a path-following library that utilizes a reactive vector follower
 that implements translational, heading, and centripetal force correction
-to dynamically converge to the target position. 
+to dynamically converge to the target position.
 
 **Links:**
 - Docs: <https://pedropathing.com>
@@ -10,13 +10,13 @@ to dynamically converge to the target position.
 - Library: <https://github.com/Pedro-Pathing/PedroPathing>
 - Visualizer: <https://visualizer.pedropathing.com>
 
-**Pros of Pedro:** 
-- Can make your bot drive faster.  
+**Pros of Pedro:**
+- Can make your bot drive faster.
 - Excellent correction for unexpected disturbances.
 - Has a no-code, browser-based path visualizer.
 - Caches motor writes by default.
 - Corrects for centripetal force to hold the robot onto curved paths.
-- Path curves can be manually set using control points. 
+- Path curves can be manually set using control points.
 
 **Cons of Pedro:**
 - Newer, so potentially buggier.
@@ -25,7 +25,7 @@ to dynamically converge to the target position.
 - Not necessarily time-consistent; speed is prioritized over consistency.
 - Visualizer uses a nonstandard (0 - 144) coordinate scheme.
 - Path curves are not automatically optimized, and must be manually set using control points.
-- Quickstart code is not under the standard TeamCode package name, 
+- Quickstart code is not under the standard TeamCode package name,
 making using SlothLoad and integrating existing projects more difficult.
 - Does not bulk read by default.
 - No logs, so no replays of each run and much more difficult debugging.
@@ -34,7 +34,7 @@ making using SlothLoad and integrating existing projects more difficult.
 ---
 
 **Road Runner** is a motion-profiling-based follower library
-that includes a command-based action system and geometry. 
+that includes a command-based action system and geometry.
 
 It prioritizes time consistency above all else.
 
@@ -58,7 +58,7 @@ It prioritizes time consistency above all else.
 **Cons of Roadrunner:**
 - Prioritizes time consistency above all else, meaning potentially worse correction.
 - Slower speed by default.
-- Path curves are less flexible then Pedro. 
+- Path curves are less flexible then Pedro.
 - Path visualizer is code based.
 - Does not cache motor writes by default.
 - No built-in centripetal force correction.
@@ -70,14 +70,14 @@ Guidelines for editing this page:
 Differences must be objective issues from a neutral point of view, not one sided.
 Ideally, people with biases in both directions should agree about these differences.
 
-Each difference will be listed twice, as a pro of one library and as a con of another. 
+Each difference will be listed twice, as a pro of one library and as a con of another.
 
 Actively avoid being reductive or summarizing into an overall recommendation;
 the idea of the page is that both libraries are good for different needs,
 and the reader should decide for themself which library aligns with their priorities.
 
 The amount of pros or cons for a library is not intended to imply that library is definitely better
-or definitely worse, and being neutral does not mean that the amount of pros and cons need to be equal. 
+or definitely worse, and being neutral does not mean that the amount of pros and cons need to be equal.
 
 If you feel that a library has too many cons, consider fixing the underlying issues they reference
 and improving the experience for all users. Let us know (in an issue, PR, or in the Cookbook Discord)
@@ -85,5 +85,3 @@ after this happens and we will be happy to remove it from the list.
 
 
 -->
-
-*Last Updated: 2025-3-29*   

--- a/src/misc/terminology_and_acronyms.md
+++ b/src/misc/terminology_and_acronyms.md
@@ -32,5 +32,3 @@
 **AS**: [Android Studio](https://developer.android.com/studio)<br>
 **OBJ**: [OnBot Java](https://ftc-docs.firstinspires.org/en/latest/programming_resources/onbot_java/OnBot-Java-Tutorial.html)<br>
 **ADB**: [Android Debug Bridge (used to wireless connect to control hub)](https://developer.android.com/tools/adb)
-
-*Last Updated: 2024-01-26*

--- a/src/pidf_controllers/integrating_a_custom_PIDF_controller.md
+++ b/src/pidf_controllers/integrating_a_custom_PIDF_controller.md
@@ -2,7 +2,7 @@
 
 *This recipe does not cover usage for Roadrunner or Command-Based structures.*
 
-[PID(F) controllers](https://www.ctrlaltftc.com/the-pid-controller) are some of the most used controllers in FTC. 
+[PID(F) controllers](https://www.ctrlaltftc.com/the-pid-controller) are some of the most used controllers in FTC.
 However, it can be confusing and challenging to properly integrate them into your OpModes.
 This recipe will go over an example of how to integrate a PID(F) controller alongside a manual control system.
 
@@ -16,7 +16,7 @@ This recipe will go over an example of how to integrate a PID(F) controller alon
 
 ### Creating a PID(F) Controller
 
-The first part of using a PID(F) controller is creating one. 
+The first part of using a PID(F) controller is creating one.
 To do this, we need to declare the PID(F) controller within the OpMode:
 
 ```java
@@ -51,10 +51,10 @@ public class ExampleOpMode extends LinearOpMode {
 }
 ```
 
-Now that we have our PID(F) controller, we need to use it! 
+Now that we have our PID(F) controller, we need to use it!
 One of the most common use cases for a PID(F) controller is moving a motor to a certain motor encoder position.
-As an example, let's say we have a linear slide, and want to move it to 500 ticks when we press "a." 
-We also want to be able to move it up and down using the triggers. 
+As an example, let's say we have a linear slide, and want to move it to 500 ticks when we press "a."
+We also want to be able to move it up and down using the triggers.
 The following code is for a LinearOpMode (the `while (opModeIsActive())` section would go in the `loop()` function for a OpMode):
 
 ```java
@@ -101,7 +101,7 @@ public void runOpMode() {
 
 ```
 
-This is a lot, so let's break it down piece by piece. 
+This is a lot, so let's break it down piece by piece.
 First, we initialize our slide motor, which we call `slides`.
 
 ```java
@@ -122,8 +122,8 @@ Gamepad lastGamepad1 = new Gamepad();
 Gamepad lastGamepad2 = new Gamepad();
 ```
 
-`targetPosition` is simply the position we want the slides to go to, which is 500. 
-`usePIDF` stores the state of our system, i.e. whether we want to run the PIDF or use manual control. 
+`targetPosition` is simply the position we want the slides to go to, which is 500.
+`usePIDF` stores the state of our system, i.e. whether we want to run the PIDF or use manual control.
 `lastGamepad1` and `lastGamepad2` are used for [Rising Edge Detectors](https://gm0.org/en/latest/docs/software/tutorials/gamepad.html?detector#rising-edge-detector).
 In short, they detect when a button begins to be pressed, and ignore when it is held.
 
@@ -145,7 +145,7 @@ if (gamepad1.a && !lastGamepad1.a) {
 
 The next part is a little complicated, but the idea is that we only want to call `slide.setPower()` once, so we group all the ways it can be called together so that they can't happen at the same time.
 
-First, we check if the left trigger is pressed. 
+First, we check if the left trigger is pressed.
 If it is, we set the slide power to an appropriate value and switch to manual control mode by setting `usePIDF` to `false`.
 
 ```java
@@ -157,7 +157,7 @@ if (gamepad1.left_trigger > 0) {
 }
 ```
 
-Next, we do the same check, but for the right trigger. 
+Next, we do the same check, but for the right trigger.
 
 
 ```java
@@ -169,7 +169,7 @@ else if (gamepad1.right_trigger > 0) {
 }
 ```
 
-Note that we use `else` to only run this code if the left trigger is not pressed. 
+Note that we use `else` to only run this code if the left trigger is not pressed.
 This prevents pressing both triggers at the same time from causing any issues.
 
 **Tip:** If your triggers return nonzero values even when they are not being pressed, you can increase the minimum value (the `0` in the statement `if (gamepad1.left_trigger > 0)`) from `0` to something like `0.1`.
@@ -183,20 +183,18 @@ else if (usePIDF) {
 }
 ```
 
-This is a pretty standard way of using the PID(F) output to set a motor power. 
+This is a pretty standard way of using the PID(F) output to set a motor power.
 `slides.getCurrentPosition()`, as the name implies, just returns the current slide position, in ticks.
 The [*FTCLib*](https://ftclib.org/) PID(F) assumes that the first input of the function is the place where your motor is, and the second input is the place where your motor wants to be.
 We will be using the *FTCLib* PID(F) syntax here for the sake of having some standard, but either way works.
 
-If you've read through this entire thing, then congrats! 
+If you've read through this entire thing, then congrats!
 You should now have a fully functioning PID(F) controller that you can implement anywhere, even in conjunction with manual control.
 
-Note that the example we went through is just one way PID(F)s can be used, and there are many ways to achieve this result. 
+Note that the example we went through is just one way PID(F)s can be used, and there are many ways to achieve this result.
 Don't worry if your code doesn't look exactly like this example!
 
-As an aside, the technique we used to make sure the PID(F) control and manual control did not interfere is a simple version of what's known as a [**Finite State Machine**](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html). 
+As an aside, the technique we used to make sure the PID(F) control and manual control did not interfere is a simple version of what's known as a [**Finite State Machine**](https://gm0.org/en/latest/docs/software/concepts/finite-state-machines.html).
 This idea of having multiple possible states and only running one at a time to ensure they don't interfere can be used for much more complex systems, such as controlling an entire Autonomous!
 
 Best of luck with your code!
-
-*Last updated: 2024-05-29*

--- a/src/roadrunner_056/is_the_bump_on_manual_feedforward_tuner_normal.md
+++ b/src/roadrunner_056/is_the_bump_on_manual_feedforward_tuner_normal.md
@@ -2,9 +2,7 @@
 
 ![image of deceleration bump](../static/is_the_bump_on_manual_feedforward_tuner_normal/deceleration_bump.png)
 
-Yes! 
-The bump when accelerating and decelerating is normal. 
+Yes!
+The bump when accelerating and decelerating is normal.
 It is caused by a fundamental hardware issue with the Control and Expansion Hubs that makes deceleration weird.
 There's nothing you can do about it; just try to get the plates and slopes to match up as closely as possible.
-
-*Last Updated: 2024-05-29*

--- a/src/roadrunner_056/manual_feed_forward_tuner_opposite_velocities.md
+++ b/src/roadrunner_056/manual_feed_forward_tuner_opposite_velocities.md
@@ -1,6 +1,6 @@
 # Target Velocity is Positive When Measured Velocity is Negative When Tuning Manual Feedforward
 
-If MotorDirectionDebugger works perfectly, this means that either your right side encoders are plugged in to the wrong ports (so swap `frontRight` and `backRight` encoder cables) or your left side encoders are plugged in to the wrong ports (so swap `frontLeft` and `backLeft` encoder cables). 
+If MotorDirectionDebugger works perfectly, this means that either your right side encoders are plugged in to the wrong ports (so swap `frontRight` and `backRight` encoder cables) or your left side encoders are plugged in to the wrong ports (so swap `frontLeft` and `backLeft` encoder cables).
 An easy way to debug this is to add a `printEncoderValues` telemetry method in `SampleMecanumDrive`.
 
 ```java
@@ -9,13 +9,9 @@ public void printEncoderValues(Telemetry telemetry) {
         telemetry.addData("RightFrontPos: ", rightFront.getCurrentPosition());
         telemetry.addData("LeftRearPos: ", leftRear.getCurrentPosition());
         telemetry.addData("RightBackPos: ", rightRear.getCurrentPosition());
-} 
+}
 ```
-Then at the end of every loop in MotorDirectionDebugger, call 
+Then at the end of every loop in MotorDirectionDebugger, call
 ```java
 drive.printEncoderValues(telemetry);
 ```
-
-
-
-*Last updated: 2024-05-30*

--- a/src/roadrunner_056/manual_feedforward_tuner_overshooots.md
+++ b/src/roadrunner_056/manual_feedforward_tuner_overshooots.md
@@ -1,10 +1,8 @@
 # Manual Feedforward Tuner Overshoots
 
-This is normal! 
-The REV hub motor controllers are not great at decelerating, so this typically causes about a 10% overshoot on manual feedforward tuner. 
-It is okay to move on to the next tuning steps. 
+This is normal!
+The REV hub motor controllers are not great at decelerating, so this typically causes about a 10% overshoot on manual feedforward tuner.
+It is okay to move on to the next tuning steps.
 
-However, when you get to the feedback tuning, whether it's "Back and Forth" or "FollowerPIDTuner," you will want to add a non-zero kD term. 
+However, when you get to the feedback tuning, whether it's "Back and Forth" or "FollowerPIDTuner," you will want to add a non-zero kD term.
 This will help the robot not overshoot.
-
-*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_drifts_to_one_side_during_manual_feedforward_tuning.md
+++ b/src/roadrunner_056/robot_drifts_to_one_side_during_manual_feedforward_tuning.md
@@ -1,9 +1,7 @@
 # Robot Drifts to One Side During Manual Feedforward Tuning
 
-If this happens, you shouldn't worry. 
-This can be caused by many reasons, such as an unbalanced robot or one wheel having slightly more friction than the others. 
+If this happens, you shouldn't worry.
+This can be caused by many reasons, such as an unbalanced robot or one wheel having slightly more friction than the others.
 
 Whatever the reason, this will be corrected for in the later tuning steps.
 It can safely be ignored.
-
-*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_drifts_while_tuning_follower_pid.md
+++ b/src/roadrunner_056/robot_drifts_while_tuning_follower_pid.md
@@ -1,13 +1,11 @@
 # Robot Drifts While Tuning Follower PID
 
 ### Check Localization
-Run `LocalizationTest` and drive the robot back and forth a few times. 
-You want to ensure that the behavior shown on the dashboard mirrors that of what you can see. 
+Run `LocalizationTest` and drive the robot back and forth a few times.
+You want to ensure that the behavior shown on the dashboard mirrors that of what you can see.
 If the robot was veering in `BackAndForth`, see if the dashboard bot is veering the same.
 If you notice the same discrepancy while running `LocalizationTest`, it means the problem is in your localization.
 
 ### Tuning PID
 If you're certain that localization works fine and the robot "knows" that it's wrong, but isn't correcting, then you need to tune your PID values more.
 You can tune your controller through the steps on [this page of Game Manual 0](https://gm0.org/en/latest/docs/software/concepts/control-loops.html#tuning-a-pid-loop).
-
-*Last Updated: 2024-01-21*

--- a/src/roadrunner_056/robot_drives_full_speed_on_start_when_following_trajectory.md
+++ b/src/roadrunner_056/robot_drives_full_speed_on_start_when_following_trajectory.md
@@ -1,12 +1,10 @@
 # Robot Drive Full Speed on Start When Following Trajectory
 
 If you are running an OpMode that has Roadrunner trajectories in it, and when you start moving it goes at full speed right away, this almost always means you forgot to set a pose estimate.
-In `init()`, before you run any trajectories, make sure you have `drive.setPoseEstimate(startingPose)`, whatever your starting pose may be. 
+In `init()`, before you run any trajectories, make sure you have `drive.setPoseEstimate(startingPose)`, whatever your starting pose may be.
 Make sure that the trajectory starting pose matches this:
 ```java
 Trajectory traj = drive.trajectoryBuilder(startingPose)
     ...
     .build();
 ```
-
-*Last Updated: 2024-01-20*

--- a/src/roadrunner_056/robot_localization_makes_circle_when_spinning_in_place.md
+++ b/src/roadrunner_056/robot_localization_makes_circle_when_spinning_in_place.md
@@ -1,21 +1,19 @@
 # Robot Localization Makes Circle When Spinning In Place
 
-So when you spin the robot in place, the drawing on FTC Dashboard is making a circle. 
+So when you spin the robot in place, the drawing on FTC Dashboard is making a circle.
 This is normal and can be fixed.
 
 ### What causes it?
-When the robot is spun, the strafing odometry wheel moves which makes the localization think the robot moved in a circle. 
+When the robot is spun, the strafing odometry wheel moves which makes the localization think the robot moved in a circle.
 This can be counteracted using the forward distance from the strafing tracking wheel to the center of rotation.
 
 ### Three Wheel Solution
-For three wheel odometry, this means your forward offset isn't tuned correctly. 
-Run the tuner and replace the value. 
-If that doesn't work, check whether the strafing pod is closer to the front or the back of the robot. 
+For three wheel odometry, this means your forward offset isn't tuned correctly.
+Run the tuner and replace the value.
+If that doesn't work, check whether the strafing pod is closer to the front or the back of the robot.
 If it's closer to the back, the offset should be negative.
 
 ### Two Wheel Solution
-The solution for two wheel odometry is largely the same. 
-Instead of the forward offset, you must tune the x and y position of the strafing pod. 
+The solution for two wheel odometry is largely the same.
+Instead of the forward offset, you must tune the x and y position of the strafing pod.
 The same advice about positive and negative offset still applies.
-
-*Last Updated: 2024-05-30*

--- a/src/roadrunner_056/robot_velocity_plateaus_below_target_velocity_plateau.md
+++ b/src/roadrunner_056/robot_velocity_plateaus_below_target_velocity_plateau.md
@@ -5,5 +5,3 @@
 This means you've reached your robot's actual max velocity.
 You should lower the max velocity specified in DriveConstants.
 Run the MaxVelocityTuner to find the recommended max velocity to use.
-
-*Last Updated: 2024-02-08*

--- a/src/roadrunner_10/complete_trajectorybuilder_reference.md
+++ b/src/roadrunner_10/complete_trajectorybuilder_reference.md
@@ -26,7 +26,7 @@ The current [TrajectoryBuilder Reference](https://rr.brott.dev/docs/v1-0/builder
 9. [`lineToX(x: double) & .lineToXConstantHeading(x: double)`](../roadrunner_10/complete_trajectorybuilder_reference.md#linetoxx-double--linetoxconstantheadingx-double)
 10. [`lineToY(y: double) & .lineToYConstantHeading(y: double)`](../roadrunner_10/complete_trajectorybuilder_reference.md#linetoyy-double--linetoyconstantheadingy-double)
 11. [`splineTo(new Vector2d(x, y), tangent)`](../roadrunner_10/complete_trajectorybuilder_reference.md#splinetonew-vector2dx-y-tangent--heading-is--fracpi6-)
-    
+
 #### [Heading Primitives:](../roadrunner_10/complete_trajectorybuilder_reference.md#heading-primitives-1)
 12. [`Tangent Heading (default)`](../roadrunner_10/complete_trajectorybuilder_reference.md#tangent-heading-default)
 13. [`Constant Heading`](../roadrunner_10/complete_trajectorybuilder_reference.md#constant-heading)
@@ -40,14 +40,14 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 #### `waitSeconds(double: seconds)`
 
-> 🚨 **WARNING:** 🚨  
+> 🚨 **WARNING:** 🚨
 > Ensure that you are using `waitSeconds()` and not `wait()`. All Java objects have a `wait()` function which causes the current thread to wait until another thread invokes a `notify()` or `notifyAll()` method. See further details in the [Oracle JavaDoc](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#wait()). We don't care for this function, but it does show up in intellisense. Make sure you are using the `waitSeconds()` function instead of `wait()`.
 
 ```java
 {{#rustdoc_include BuilderReference.java:1:4}}
 ```
 <div class="video-container-1">
-    <iframe width="505" height="650" 
+    <iframe width="505" height="650"
         src="../static/builder_reference_videos/waitSeconds().mp4" title="waitSeconds()" style="border: none;" playsinline controls>
     </iframe>
 </div>
@@ -67,7 +67,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-1 iframe {
         width: 328px;
         height: 423px;
@@ -103,7 +103,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-2 iframe {
         width: 328px;
         height: 423px;
@@ -111,10 +111,10 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 }
 </style>
 
-> **Why Radians?**  
-> You may have noticed that we are turning by \\( \frac{\pi}{6} \\) degrees instead of degrees. 
+> **Why Radians?**
+> You may have noticed that we are turning by \\( \frac{\pi}{6} \\) degrees instead of degrees.
 > This is because Road Runner 1.0's units are inches and radians by default. To use degrees, we can convert degrees to radians by using Java's `Math.toRadians(degrees)`
-> 
+>
 > Example:
 > `Math.toRadians(90)` converts 90 degrees to radians. 90 degrees is the same as \\( \frac{\pi}{2} \\) radians.
 
@@ -147,7 +147,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-3 iframe {
         width: 328px;
         height: 423px;
@@ -192,7 +192,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-4 iframe {
         width: 328px;
         height: 423px;
@@ -225,7 +225,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-5 iframe {
         width: 328px;
         height: 423px;
@@ -266,7 +266,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-6 iframe {
         width: 328px;
         height: 423px;
@@ -303,7 +303,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-7 iframe {
         width: 328px;
         height: 423px;
@@ -340,7 +340,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-8 iframe {
         width: 328px;
         height: 423px;
@@ -357,7 +357,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 #### `lineToX(x: double)` & `.lineToXConstantHeading(x: double)`
 
-> 🚨 **WARNING:** 🚨  
+> 🚨 **WARNING:** 🚨
 > It is **HIGHLY RECOMMENDED** to use [`.strafeTo()`](../roadrunner_10/complete_trajectorybuilder_reference.md) instead of any `lineTo()`'s! 🚨
 
 ```java
@@ -385,7 +385,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-9 iframe {
         width: 328px;
         height: 423px;
@@ -397,7 +397,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 #### `lineToY(y: double)` & `.lineToYConstantHeading(y: double)`
 
-> 🚨 **WARNING:** 🚨  
+> 🚨 **WARNING:** 🚨
 > It is **HIGHLY RECOMMENDED** to use [`.strafeTo()`](../roadrunner_10/complete_trajectorybuilder_reference.md) instead of any `lineTo()`'s! 🚨
 
 ```java
@@ -425,7 +425,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-10 iframe {
         width: 328px;
         height: 423px;
@@ -462,7 +462,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-11 iframe {
         width: 328px;
         height: 423px;
@@ -503,7 +503,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-12 iframe {
         width: 328px;
         height: 423px;
@@ -540,7 +540,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-13 iframe {
         width: 328px;
         height: 423px;
@@ -557,7 +557,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
 ```
 
 <div class="video-container-1">
-    <video width="505" height="650" 
+    <video width="505" height="650"
         src="../static/builder_reference_videos/splineToLinearHeading().mp4" title="splineToLinearHeading()" style="border: none;" playsinline controls>
     </video>
 </div>
@@ -577,7 +577,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-14 iframe {
         width: 328px;
         height: 423px;
@@ -614,7 +614,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
         width: 328px;
         height: 423px;
     }
-    
+
     .video-container-15 iframe {
         width: 328px;
         height: 423px;
@@ -645,4 +645,3 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
 - [`.splineToSplineHeading()` Video Playground](https://rr.brott.dev/playground/?9c422405d44fed70)
 
 ---
-*Last Updated: 2025-01-28*

--- a/src/roadrunner_10/null_list_error_in_rr_10.md
+++ b/src/roadrunner_10/null_list_error_in_rr_10.md
@@ -15,6 +15,3 @@ If you have gotten through Road Runner 1.0 tuning to the ForwardRampLogger tunin
 ### Solution
 You must first run the OpMode from the Driver Station and then stop it once the robot's speed stops increasing.
 Finally, you can open the tuning page on your robot's Wi-Fi network, as the Road Runner docs say.
-
-
-*Last Updated: 2024-05-29*


### PR DESCRIPTION
This PR adds my mdbook-blame mdbook preprocessor. Mdbook will happily build locally without it, so no need for users to install it directly.

It adds blocks to the bottom of the pages like so:
![image](https://github.com/user-attachments/assets/53136a55-b5cf-40cf-b4ba-e1cf7851bb0a)
This data is derived from git history.

In the future, I'd like to add user profile pages to allow you to see which pages a user has edited most, and their contribution history.

Opening a PR to see comments on anything that needs to change about the preprocessor.

Also, to mark any files that have dates at the bottom of the page to be removed.