### PR TITLE
fix: correct some TrajectoryBuilder units and constructors

### DIFF
--- a/src/roadrunner_10/BuilderReference.java
+++ b/src/roadrunner_10/BuilderReference.java
@@ -10,8 +10,8 @@
 // If you see `Math.PI`, it is already in radians, and does not need `Math.toRadians()`. Degrees from 0 to 360 need to be converted to radians.
 // To turn clockwise, use a negative angle.
 
-.turn(-Math.PI / 6) // Turns clockwise by `Math.PI / 6` degrees, ending at a heading of 0 degrees
-.turn(Math.PI / 6) // Turns counterclockwise by `Math.PI / 6` degrees, ending at the original heading
+.turn(-Math.PI / 6) // Turns clockwise by `Math.PI / 6` radians (30 degrees), ending at a heading of 0 degrees
+.turn(Math.PI / 6) // Turns counterclockwise by `Math.PI / 6` radians (30 degrees), ending at the original heading
 
 
 
@@ -22,14 +22,14 @@
 // If it still does not work, you can use the `turn()` method instead.
 
 .turnTo(Math.toRadians(90)) // Turns to a heading of 90 degrees
-.turnTo(Math.PI / 6) // Turns to a heading of `Math.PI / 6` degrees, ending at the original heading
+.turnTo(Math.PI / 6) // Turns to a heading of `Math.PI / 6` radians, ending at the original heading
 
 
 
 // `setTangent()` allows you to set a heading tangent on a trajectory, allowing you to follow a trajectory at arbitrary heading tangents
 // This is equivalent to specifying a custom tangent in the `TrajectoryBuilder()` constructor.
 
-.setTangent(90) // Sets tangent to 90
+.setTangent(Math.toRadians(90)) // Sets tangent to 90 degrees
 
 
 
@@ -38,29 +38,29 @@
 // This can be fixed by reversing the path using `setReversed(true)`.
 
 .setReversed(false)  // Unreversed trajectory has hooks on the start and end
-.splineTo(Vector2d(-48.0, -24.0), -Math.PI / 2)
+.splineTo(new Vector2d(-48.0, -24.0), -Math.PI / 2)
 .setReversed(false)
-.splineTo(Vector2d(-48.0, 0.0), Math.PI)
+.splineTo(new Vector2d(-48.0, 0.0), Math.PI)
 
 
 
 .setReversed(true)  // Reversed trajectory has no hooks on the start and end, and is smooth
-.splineTo(Vector2d(-48.0, -24.0), -Math.PI / 2)
+.splineTo(new Vector2d(-48.0, -24.0), -Math.PI / 2)
 .setReversed(false)
-.splineTo(Vector2d(-48.0, 0.0), Math.PI)
+.splineTo(new Vector2d(-48.0, 0.0), Math.PI)
 
 
 
 // By default, each trajectory is set to `setReversed(false)`, which does not reverse the paths.
 // This means that:
 .setReversed(false)
-.splineTo(Vector2d(-48.0, -24.0), -Math.PI / 2)
+.splineTo(new Vector2d(-48.0, -24.0), -Math.PI / 2)
 .setReversed(false)
-.splineTo(Vector2d(-48.0, 0.0), Math.PI)
+.splineTo(new Vector2d(-48.0, 0.0), Math.PI)
 
 // Is the same as:
-.splineTo(Vector2d(-48.0, -24.0), -Math.PI / 2)
-.splineTo(Vector2d(-48.0, 0.0), Math.PI)
+.splineTo(new Vector2d(-48.0, -24.0), -Math.PI / 2)
+.splineTo(new Vector2d(-48.0, 0.0), Math.PI)
 
 
 

--- a/src/roadrunner_10/complete_trajectorybuilder_reference.md
+++ b/src/roadrunner_10/complete_trajectorybuilder_reference.md
@@ -16,8 +16,8 @@ The current [TrajectoryBuilder Reference](https://rr.brott.dev/docs/v1-0/builder
 
 #### [Path Primitives:](../roadrunner_10/complete_trajectorybuilder_reference.md#path-primitives-1)
 1. [`waitSeconds(double: seconds)`](../roadrunner_10/complete_trajectorybuilder_reference.md#waitsecondsdouble-seconds)
-2. [`turn(Math.toRadians(double: angle))`](../roadrunner_10/complete_trajectorybuilder_reference.md#turnmathtoradiansdouble-angle)
-3. [`turnTo(Math.toRadians(double: heading))`](../roadrunner_10/complete_trajectorybuilder_reference.md#turntomathtoradiansdouble-heading)
+2. [`turn(Math.toRadians(double: degrees))`](../roadrunner_10/complete_trajectorybuilder_reference.md#turnmathtoradiansdouble-degrees)
+3. [`turnTo(Math.toRadians(double: degrees))`](../roadrunner_10/complete_trajectorybuilder_reference.md#turntomathtoradiansdouble-degrees)
 4. [`setTangent(double: r)`](../roadrunner_10/complete_trajectorybuilder_reference.md#settangentdouble-r)
 5. [`setReversed(boolean: reversed)`](../roadrunner_10/complete_trajectorybuilder_reference.md#setreversedboolean-reversed)
 6. [`.strafeTo(new Vector2d(double: x, double: y))` & `.strafeToConstantHeading(new Vector2d(x: double, y: double))`](../roadrunner_10/complete_trajectorybuilder_reference.md#strafetonew-vector2ddouble-x-double-y--strafetoconstantheadingnew-vector2dx-double-y-double)
@@ -25,7 +25,7 @@ The current [TrajectoryBuilder Reference](https://rr.brott.dev/docs/v1-0/builder
 8. [`strafeToSplineHeading(new Vector2d(x, y), Math.toRadians(heading))`](../roadrunner_10/complete_trajectorybuilder_reference.md#strafetosplineheadingnew-vector2dx-y-mathtoradiansheading)
 9. [`lineToX(x: double) & .lineToXConstantHeading(x: double)`](../roadrunner_10/complete_trajectorybuilder_reference.md#linetoxx-double--linetoxconstantheadingx-double)
 10. [`lineToY(y: double) & .lineToYConstantHeading(y: double)`](../roadrunner_10/complete_trajectorybuilder_reference.md#linetoyy-double--linetoyconstantheadingy-double)
-11. [`splineTo(new Vector2d(x, y), tangent)`](../roadrunner_10/complete_trajectorybuilder_reference.md#splinetonew-vector2dx-y-tangent--heading-is--fracpi6-)
+11. [`splineTo(new Vector2d(x, y), tangent)`](../roadrunner_10/complete_trajectorybuilder_reference.md#splinetonew-vector2dx-y-tangent--start-heading-is--fracpi2--radians)
 
 #### [Heading Primitives:](../roadrunner_10/complete_trajectorybuilder_reference.md#heading-primitives-1)
 12. [`Tangent Heading (default)`](../roadrunner_10/complete_trajectorybuilder_reference.md#tangent-heading-default)
@@ -35,7 +35,7 @@ The current [TrajectoryBuilder Reference](https://rr.brott.dev/docs/v1-0/builder
 
 ### Path Primitives
 
-The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), with the exception of [`splineTo(new Vector2d(x, y), tangent)`](../roadrunner_10/complete_trajectorybuilder_reference.md#splinetonew-vector2dx-y-tangent--heading-is--fracpi6-), which has a heading of \\( \frac{\pi}{2} \\).
+The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\) radians, with the exception of [`splineTo(new Vector2d(x, y), tangent)`](../roadrunner_10/complete_trajectorybuilder_reference.md#splinetonew-vector2dx-y-tangent--start-heading-is--fracpi2--radians), which has a heading of \\( \frac{\pi}{2} \\).
 
 
 #### `waitSeconds(double: seconds)`
@@ -76,7 +76,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 </style>
 ---
 
-#### `turn(Math.toRadians(double: angle))`
+#### `turn(Math.toRadians(double: degrees))`
 
 ```java
 {{#rustdoc_include BuilderReference.java:8:14}}
@@ -112,7 +112,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 </style>
 
 > **Why Radians?**
-> You may have noticed that we are turning by \\( \frac{\pi}{6} \\) degrees instead of degrees.
+> You may have noticed that we are turning by \\( \frac{\pi}{6} \\) radians instead of 30 degrees.
 > This is because Road Runner 1.0's units are inches and radians by default. To use degrees, we can convert degrees to radians by using Java's `Math.toRadians(degrees)`
 >
 > Example:
@@ -120,7 +120,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 ---
 
-#### `turnTo(Math.toRadians(double: heading))`
+#### `turnTo(Math.toRadians(double: degrees))`
 
 ```java
 {{#rustdoc_include BuilderReference.java:18:25}}
@@ -162,6 +162,9 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 ```java
 {{#rustdoc_include BuilderReference.java:29:32}}
 ```
+>**Tip!**
+>
+>You can learn more about tangents in RoadRunner [here](https://rr.brott.dev/docs/v1-0/guides/tangents/).
 
 ---
 
@@ -435,7 +438,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 ---
 
-#### `splineTo(new Vector2d(x, y), tangent)` | Heading is \\( \frac{\pi}{6} \\)
+#### `splineTo(new Vector2d(x, y), tangent)` | Start heading is \\( \frac{\pi}{2} \\) radians
 
 ```java
 {{#rustdoc_include BuilderReference.java:108:110}}
@@ -474,7 +477,7 @@ The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{6} \\), wi
 
 ### Heading Primitives
 
-The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\).
+The begin pose is the origin `(0,0)` with a heading of \\( \frac{\pi}{2} \\) radians.
 
 #### `Tangent Heading (default)`
 


### PR DESCRIPTION
Fixes #33.

Did a fine comb over all the TrajectoryBuilder examples and fixed some issues (degrees/radians issues, missing `new`), adding a bit more clarification. Also added a tip to the official docs to explain tangents more as there isn't much info on them here.