### PR TITLE
Update Discord Invite Link

### DIFF
--- a/src/intro_to_programming/setup.md
+++ b/src/intro_to_programming/setup.md
@@ -99,4 +99,4 @@ Access to **Admin Permissions** on aforementioned computer.<br>
 Congratulations! You have successfully installed the necessary software to program an FTC robot. You can now start programming your robot.
 
 ## Troubleshooting
-- If you have questions/issues with the installation process, the [Unofficial FTC Discord](https://discord.gg/first-tech-challenge) has many experienced programmers who can help you with all sorts of issues, including installation issues.
+- If you have questions/issues with the installation process, the [Unofficial FTC Discord](https://discord.gg/ftc) has many experienced programmers who can help you with all sorts of issues, including installation issues.


### PR DESCRIPTION
The Discord link in the cookbook is no longer valid, as the server has been changed.